### PR TITLE
refactor: rename project from flexy-db to flex-db

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ A **Database-as-a-Service (DBaaS)** built with Go, gRPC, and PostgreSQL. This se
 ## Project Structure
 
 ```
-flexy-db/
+flex-db/
 ├── api/proto/              # gRPC protobuf definitions
 │   ├── dbaas.proto
 │   ├── dbaas.pb.go         # Generated Go code

--- a/api/proto/dbaas.pb.go
+++ b/api/proto/dbaas.pb.go
@@ -3718,7 +3718,7 @@ const file_api_proto_dbaas_proto_rawDesc = "" +
 	"\x0fGetRelationship\x12\x1d.dbaas.GetRelationshipRequest\x1a\x1e.dbaas.GetRelationshipResponse\x12Y\n" +
 	"\x12UpdateRelationship\x12 .dbaas.UpdateRelationshipRequest\x1a!.dbaas.UpdateRelationshipResponse\x12Y\n" +
 	"\x12DeleteRelationship\x12 .dbaas.DeleteRelationshipRequest\x1a!.dbaas.DeleteRelationshipResponse\x12V\n" +
-	"\x11ListRelationships\x12\x1f.dbaas.ListRelationshipsRequest\x1a .dbaas.ListRelationshipsResponseB.Z,github.com/hemanthpathath/flexy-db/api/protob\x06proto3"
+	"\x11ListRelationships\x12\x1f.dbaas.ListRelationshipsRequest\x1a .dbaas.ListRelationshipsResponseB.Z,github.com/hemanthpathath/flex-db/api/protob\x06proto3"
 
 var (
 	file_api_proto_dbaas_proto_rawDescOnce sync.Once

--- a/api/proto/dbaas.proto
+++ b/api/proto/dbaas.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package dbaas;
 
-option go_package = "github.com/hemanthpathath/flexy-db/api/proto";
+option go_package = "github.com/hemanthpathath/flex-db/api/proto";
 
 import "google/protobuf/timestamp.proto";
 

--- a/cmd/dbaas-server/main.go
+++ b/cmd/dbaas-server/main.go
@@ -9,11 +9,11 @@ import (
 	"strconv"
 	"syscall"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	"github.com/hemanthpathath/flexy-db/internal/db"
-	grpchandlers "github.com/hemanthpathath/flexy-db/internal/grpc"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	"github.com/hemanthpathath/flex-db/internal/db"
+	grpchandlers "github.com/hemanthpathath/flex-db/internal/grpc"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/hemanthpathath/flexy-db
+module github.com/hemanthpathath/flex-db
 
 go 1.24.10
 

--- a/internal/grpc/errors/errors.go
+++ b/internal/grpc/errors/errors.go
@@ -4,7 +4,7 @@ import (
 	"errors"
 	"strings"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 )

--- a/internal/grpc/node_handler.go
+++ b/internal/grpc/node_handler.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	grpcerrors "github.com/hemanthpathath/flexy-db/internal/grpc/errors"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	grpcerrors "github.com/hemanthpathath/flex-db/internal/grpc/errors"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/grpc/nodetype_handler.go
+++ b/internal/grpc/nodetype_handler.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	grpcerrors "github.com/hemanthpathath/flexy-db/internal/grpc/errors"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	grpcerrors "github.com/hemanthpathath/flex-db/internal/grpc/errors"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/grpc/relationship_handler.go
+++ b/internal/grpc/relationship_handler.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	grpcerrors "github.com/hemanthpathath/flexy-db/internal/grpc/errors"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	grpcerrors "github.com/hemanthpathath/flex-db/internal/grpc/errors"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/grpc/tenant_handler.go
+++ b/internal/grpc/tenant_handler.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	grpcerrors "github.com/hemanthpathath/flexy-db/internal/grpc/errors"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	grpcerrors "github.com/hemanthpathath/flex-db/internal/grpc/errors"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/grpc/user_handler.go
+++ b/internal/grpc/user_handler.go
@@ -3,10 +3,10 @@ package grpc
 import (
 	"context"
 
-	pb "github.com/hemanthpathath/flexy-db/api/proto"
-	grpcerrors "github.com/hemanthpathath/flexy-db/internal/grpc/errors"
-	"github.com/hemanthpathath/flexy-db/internal/repository"
-	"github.com/hemanthpathath/flexy-db/internal/service"
+	pb "github.com/hemanthpathath/flex-db/api/proto"
+	grpcerrors "github.com/hemanthpathath/flex-db/internal/grpc/errors"
+	"github.com/hemanthpathath/flex-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/service"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 

--- a/internal/service/node_service.go
+++ b/internal/service/node_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 )
 
 // NodeService handles node business logic

--- a/internal/service/nodetype_service.go
+++ b/internal/service/nodetype_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 )
 
 // NodeTypeService handles node type business logic

--- a/internal/service/relationship_service.go
+++ b/internal/service/relationship_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 )
 
 // RelationshipService handles relationship business logic

--- a/internal/service/tenant_service.go
+++ b/internal/service/tenant_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 )
 
 // TenantService handles tenant business logic

--- a/internal/service/user_service.go
+++ b/internal/service/user_service.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/hemanthpathath/flexy-db/internal/repository"
+	"github.com/hemanthpathath/flex-db/internal/repository"
 )
 
 // UserService handles user business logic


### PR DESCRIPTION
## Summary
This PR updates all references to the old project name `flexy-db` to the new name `flex-db`.

## Changes
- ✅ Updated module name in `go.mod`
- ✅ Updated all import paths across the codebase (16 files)
- ✅ Updated proto file `go_package` option
- ✅ Updated `README.md` project structure section
- ✅ Updated generated proto files

## Files Changed
- `go.mod`
- `api/proto/dbaas.proto`
- `api/proto/dbaas.pb.go`
- `README.md`
- All service files in `internal/service/`
- All handler files in `internal/grpc/`
- `cmd/dbaas-server/main.go`
- `internal/grpc/errors/errors.go`

## Testing
- [ ] Verify all imports resolve correctly
- [ ] Run `go mod tidy` to ensure dependencies are updated
- [ ] Consider regenerating proto files with `protoc`